### PR TITLE
add-read-item

### DIFF
--- a/service/routes.py
+++ b/service/routes.py
@@ -260,6 +260,27 @@ def delete_wishlists(wishlist_id):
     return "", status.HTTP_204_NO_CONTENT
 
 
+# READ A ITEM
+@app.route("/items/<int:item_id>", methods=["GET"])
+def get_items(item_id):
+    """
+    Retrieve a single Items
+
+    This endpoint will return a Items based on it's id
+    """
+    app.logger.info("Request for item with id: %s", item_id)
+
+    item = Item.find(item_id)
+    if not item:
+        error(
+            status.HTTP_404_NOT_FOUND,
+            f"Items with id '{item_id}' was not found.",
+        )
+
+    app.logger.info("Returning item: %s", item.id)
+    return jsonify(item.serialize()), status.HTTP_200_OK
+
+
 # READ A WISHLIST
 @app.route("/wishlists/<int:wishlist_id>", methods=["GET"])
 def get_wishlists(wishlist_id):

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -225,3 +225,14 @@ class TestWishlists(TestCase):
         item = self._create_wishlists(1)[0]
         resp = self.client.delete(f"{BASE_URL}/{item.id}")
         self.assertEqual(resp.status_code, status.HTTP_204_NO_CONTENT)
+
+        # Read an item
+
+    def test_get_item(self):
+        """It should Get a single Item"""
+        # get the id of an item
+        test_item = self._create_wishlists(1)[0]
+        response = self.client.get(f"{BASE_URL}/{test_item.id}")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.get_json()
+        self.assertEqual(data["id"], test_item.id)


### PR DESCRIPTION
Added in endpoint for add-read-item

- made updates to test_routes.py
- made updates to routes.py

One test case still failing: update an item due to 405! = 200 error. At 70% test coverage.